### PR TITLE
Update near-indexer-primitives version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ tokio = { version = "1.35.1", features = ["sync", "time", "rt", "macros"] }
 tokio-stream = { version = "0.1.14" }
 tracing = "0.1.40"
 
-near-indexer-primitives = "0.23.0"
+near-indexer-primitives = { git = "https://github.com/near/nearcore", tag = "1.37.1" }
 
 [lib]
 doctest = false


### PR DESCRIPTION
This version update is required to align dependencies to use the same version of near-primitives.

We have to use 0.7.x version to avoid updating lake APIs.